### PR TITLE
Changed Operation struct

### DIFF
--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -410,6 +410,26 @@ func (c *Client) StreamEffects(
 	})
 }
 
+// StreamOperations streams incoming operations. Use context.WithCancel to stop streaming or
+// context.Background() if you want to stream indefinitely.
+func (c *Client) StreamOperations(
+	ctx context.Context,
+	cursor *Cursor,
+	handler OperationHandler,
+) (err error) {
+	c.fixURLOnce.Do(c.fixURL)
+	url := fmt.Sprintf("%s/operations", c.URL)
+	return c.stream(ctx, url, cursor, func(data []byte) error {
+		var operation Operation
+		err = json.Unmarshal(data, &operation)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(operation)
+		return nil
+	})
+}
+
 // StreamLedgers streams incoming ledgers. Use context.WithCancel to stop streaming or
 // context.Background() if you want to stream indefinitely.
 func (c *Client) StreamLedgers(

--- a/clients/horizon/client.go
+++ b/clients/horizon/client.go
@@ -390,6 +390,26 @@ func (c *Client) stream(
 	}
 }
 
+// StreamEffects streams incoming effects. Use context.WithCancel to stop streaming or
+// context.Background() if you want to stream indefinitely.
+func (c *Client) StreamEffects(
+	ctx context.Context,
+	cursor *Cursor,
+	handler EffectHandler,
+) (err error) {
+	c.fixURLOnce.Do(c.fixURL)
+	url := fmt.Sprintf("%s/effects", c.URL)
+	return c.stream(ctx, url, cursor, func(data []byte) error {
+		var effect Effect
+		err = json.Unmarshal(data, &effect)
+		if err != nil {
+			return errors.Wrap(err, "Error unmarshaling data")
+		}
+		handler(effect)
+		return nil
+	})
+}
+
 // StreamLedgers streams incoming ledgers. Use context.WithCancel to stop streaming or
 // context.Background() if you want to stream indefinitely.
 func (c *Client) StreamLedgers(

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -97,6 +97,7 @@ type ClientInterface interface {
 	LoadMemo(p *Payment) error
 	LoadOrderBook(selling Asset, buying Asset, params ...interface{}) (orderBook OrderBookSummary, err error)
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
+	StreamEffects(ctx context.Context, cursor *Cursor, handler EffectHandler) error
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
 	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
@@ -115,6 +116,9 @@ type HTTP interface {
 	Get(url string) (resp *http.Response, err error)
 	PostForm(url string, data url.Values) (resp *http.Response, err error)
 }
+
+// EffectHandler is a function that is called when a new effect is received
+type EffectHandler func(Effect)
 
 // LedgerHandler is a function that is called when a new ledger is received
 type LedgerHandler func(Ledger)

--- a/clients/horizon/main.go
+++ b/clients/horizon/main.go
@@ -98,6 +98,7 @@ type ClientInterface interface {
 	LoadOrderBook(selling Asset, buying Asset, params ...interface{}) (orderBook OrderBookSummary, err error)
 	SequenceForAccount(accountID string) (xdr.SequenceNumber, error)
 	StreamEffects(ctx context.Context, cursor *Cursor, handler EffectHandler) error
+	StreamOperations(ctx context.Context, cursor *Cursor, handler OperationHandler) error
 	StreamLedgers(ctx context.Context, cursor *Cursor, handler LedgerHandler) error
 	StreamPayments(ctx context.Context, accountID string, cursor *Cursor, handler PaymentHandler) error
 	StreamTransactions(ctx context.Context, accountID string, cursor *Cursor, handler TransactionHandler) error
@@ -119,6 +120,9 @@ type HTTP interface {
 
 // EffectHandler is a function that is called when a new effect is received
 type EffectHandler func(Effect)
+
+// OperationHandler is a function that is called when a new effect is received
+type OperationHandler func(Operation)
 
 // LedgerHandler is a function that is called when a new ledger is received
 type LedgerHandler func(Ledger)

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -101,6 +101,12 @@ func (m *MockClient) StreamEffects(ctx context.Context, cursor *Cursor, handler 
 	return a.Error(0)
 }
 
+// StreamOperations is a mocking a method
+func (m *MockClient) StreamOperations(ctx context.Context, cursor *Cursor, handler OperationHandler) error {
+	a := m.Called(ctx, cursor, handler)
+	return a.Error(0)
+}
+
 // StreamLedgers is a mocking a method
 func (m *MockClient) StreamLedgers(
 	ctx context.Context,

--- a/clients/horizon/mocks.go
+++ b/clients/horizon/mocks.go
@@ -95,6 +95,12 @@ func (m *MockClient) SequenceForAccount(accountID string) (xdr.SequenceNumber, e
 	return a.Get(0).(xdr.SequenceNumber), a.Error(1)
 }
 
+// StreamEffects is a mocking a method
+func (m *MockClient) StreamEffects(ctx context.Context, cursor *Cursor, handler EffectHandler) error {
+	a := m.Called(ctx, cursor, handler)
+	return a.Error(0)
+}
+
 // StreamLedgers is a mocking a method
 func (m *MockClient) StreamLedgers(
 	ctx context.Context,

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -125,6 +125,23 @@ type HistoryAccount struct {
 	AccountID string `json:"account_id"`
 }
 
+type Effect struct {
+	Links struct {
+		Operation Link `json:"operation"`
+		Succeeds  Link `json:"succeeds"`
+		Precedes  Link `json:"precedes"`
+	} `json:"_links"`
+	ID              string `json:"id"`
+	PT              string `json:"paging_token"`
+	Account         string `json:"account"`
+	Amount          string `json:"amount"`
+	Type            string `json:"type"`
+	TypeI           int32  `json:"type_i"`
+	StartingBalance string `json:"starting_balance"`
+	Balance
+	Signer
+}
+
 type Ledger struct {
 	Links struct {
 		Self         Link `json:"self"`

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -144,21 +144,92 @@ type Effect struct {
 
 type Operation struct {
 	Links struct {
+		Self        Link `json:"self"`
 		Transaction Link `json:"transaction"`
 		Effects     Link `json:"effects"`
 		Succeeds    Link `json:"succeeds"`
 		Precedes    Link `json:"precedes"`
 	} `json:"_links"`
-	ID              string `json:"id"`
-	PT              string `json:"paging_token"`
-	Account         string `json:"account"`
-	SourceAccount   string `json:"source_account"`
-	Type            string `json:"type"`
-	TypeI           int32  `json:"type_i"`
+
+	ID              string    `json:"id"`
+	PT              string    `json:"paging_token"`
+	SourceAccount   string    `json:"source_account"`
+	Type            string    `json:"type"`
+	TypeI           int32     `json:"type_i"`
+	LedgerCloseTime time.Time `json:"created_at"`
+	TransactionHash string    `json:"transaction_hash"`
+
+	// account_merge and create_account field
+	Account string `json:"account"`
+
+	// account_merge field
+	Into string `json:"into"`
+
+	// create_account fields
 	StartingBalance string `json:"starting_balance"`
-	CreatedAt       string `json:"created_at"`
 	Funder          string `json:"funder"`
-	TransactionHash string `json:"transaction_hash"`
+
+	// allow_trust, change_trust, payment and path_payment
+	Asset
+
+	// allow_trust and change_trust fields
+	Trustee string `json:"trustee"`
+	Trustor string `json:"trustor"`
+
+	// allow_trust fields
+	Authorize bool   `json:"authorize"`
+
+	// change_trust field
+	Limit   string `json:"limit"`
+
+	// payment, path_payment, create_passive_order and manage_offer field
+	Amount string `json:"amount"`
+
+	// payment and path_payment fields
+	From   string `json:"from"`
+	To     string `json:"to"`
+
+	// path_payment fields
+	Path              []Asset `json:"path"`
+	SourceAmount      string  `json:"source_amount"`
+	SourceMax         string  `json:"source_max"`
+	SourceAssetType   string  `json:"source_asset_type"`
+	SourceAssetCode   string  `json:"source_asset_code,omitempty"`
+	SourceAssetIssuer string  `json:"source_asset_issuer,omitempty"`
+
+	// create_passive_order and manage_offer fields
+	Price              string `json:"price"`
+	PriceR             Price 	`json:"price_r"`
+	BuyingAssetType    string `json:"buying_asset_type"`
+	BuyingAssetCode    string `json:"buying_asset_code,omitempty"`
+	BuyingAssetIssuer  string `json:"buying_asset_issuer,omitempty"`
+	SellingAssetType   string `json:"selling_asset_type"`
+	SellingAssetCode   string `json:"selling_asset_code,omitempty"`
+	SellingAssetIssuer string `json:"selling_asset_issuer,omitempty"`
+
+	// manage_offer field
+	OfferID int64 `json:"offer_id"`
+
+	// manage_data fields
+	Name  string `json:"name"`
+	Value string `json:"value"`
+
+	// set_options fields
+	HomeDomain    string `json:"home_domain,omitempty"`
+	InflationDest string `json:"inflation_dest,omitempty"`
+
+	MasterKeyWeight *int   `json:"master_key_weight,omitempty"`
+	SignerKey       string `json:"signer_key,omitempty"`
+	SignerWeight    *int   `json:"signer_weight,omitempty"`
+
+	SetFlags    []int    `json:"set_flags,omitempty"`
+	SetFlagsS   []string `json:"set_flags_s,omitempty"`
+	ClearFlags  []int    `json:"clear_flags,omitempty"`
+	ClearFlagsS []string `json:"clear_flags_s,omitempty"`
+
+	LowThreshold  *int `json:"low_threshold,omitempty"`
+	MedThreshold  *int `json:"med_threshold,omitempty"`
+	HighThreshold *int `json:"high_threshold,omitempty"`
 }
 
 type Ledger struct {

--- a/clients/horizon/responses.go
+++ b/clients/horizon/responses.go
@@ -142,6 +142,25 @@ type Effect struct {
 	Signer
 }
 
+type Operation struct {
+	Links struct {
+		Transaction Link `json:"transaction"`
+		Effects     Link `json:"effects"`
+		Succeeds    Link `json:"succeeds"`
+		Precedes    Link `json:"precedes"`
+	} `json:"_links"`
+	ID              string `json:"id"`
+	PT              string `json:"paging_token"`
+	Account         string `json:"account"`
+	SourceAccount   string `json:"source_account"`
+	Type            string `json:"type"`
+	TypeI           int32  `json:"type_i"`
+	StartingBalance string `json:"starting_balance"`
+	CreatedAt       string `json:"created_at"`
+	Funder          string `json:"funder"`
+	TransactionHash string `json:"transaction_hash"`
+}
+
 type Ledger struct {
 	Links struct {
 		Self         Link `json:"self"`


### PR DESCRIPTION
Based on how the `Payment` struct defines the fields for all the possible situations, this changes the `Operation` struct to have fields for all the possible operation types.
This struct was also declared in a similar way in the [`stream_effects`](https://github.com/chr4/go-stellar-sdk/commit/cbeaa9375e32f27d4de271e59ce762df2b74dfe3) branch, by @jedmccaleb, in 2017.

The fields themselves were copied from the [`protocols/horizon`](https://github.com/stellar/go/blob/master/protocols/horizon/operations/main.go) package, added in [`refactor common resources out of horizon`](https://github.com/stellar/go/pull/433).